### PR TITLE
fix: docker build error

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+*.md
+.husky
+.github
+.editorconfig

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,14 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 COPY package*.json tsconfig*.json ./
 RUN npm ci
+COPY prisma ./prisma/
+RUN npx prisma generate
 COPY ./ ./
 RUN npm run build
 
 FROM node:22-alpine
 WORKDIR /app
 RUN npm install -g serve
-COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/out/ ./build
 EXPOSE 3000
-CMD ["serve", "-s", "dist", "-l", "3000"]
+CMD ["serve", "-s", "build", "-l", "3000"]

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type {NextConfig} from "next";
 
 const nextConfig: NextConfig = {
     reactStrictMode: true,
+    output: "export"
 }
 
 export default nextConfig;


### PR DESCRIPTION
I had the following error when i ran `docker compose up -d`
```
8.380 Error: @prisma/client did not initialize yet. Please run "prisma generate" and try to import it again.
8.380     at 4747 (.next/server/app/api/login/route.js:1:1459)
8.380     at t (.next/server/webpack-runtime.js:1:127)
8.380     at 1378 (.next/server/app/api/login/route.js:1:386)
8.380     at t (.next/server/webpack-runtime.js:1:127)
8.380     at t (.next/server/app/api/login/route.js:1:1824)
8.380     at <unknown> (.next/server/app/api/login/route.js:1:1859)
8.380     at t.X (.next/server/webpack-runtime.js:1:1191)
8.380     at <unknown> (.next/server/app/api/login/route.js:1:1837)
8.380     at Object.<anonymous> (.next/server/app/api/login/route.js:1:1886)
8.383
8.383 > Build error occurred
8.385 [Error: Failed to collect page data for /api/login] { type: 'Error' }
```