### PR TITLE
fix: can't set middleware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN npm run build
 
 FROM node:22-alpine
 WORKDIR /app
-RUN npm install -g serve
-COPY --from=builder /app/out/ ./build
-EXPOSE 3000
-CMD ["serve", "-s", "build", "-l", "3000"]
+COPY --from=builder /app ./
+RUN npm ci --omit=dev --ignore-scripts
+ENTRYPOINT ["npm", "run", "start"]

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,7 @@
 import type {NextConfig} from "next";
 
 const nextConfig: NextConfig = {
-    reactStrictMode: true,
-    output: "export"
+    reactStrictMode: true
 }
 
 export default nextConfig;


### PR DESCRIPTION
Based on the previous PR #4, using ``"output": "export"`` causes a static export.  
I changed the Dockerfile to run the app in server mode.